### PR TITLE
NodeJS 10 migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "glob": "7.1.2",
     "lodash": "4.17.10",
     "meow": "3.1.0",
-    "provisioning": "https://github.com/Icenium/provisioning/tarball/c9265bd4efe88f2983356e4c59c9d935e9c61086",
+    "provisioning": "https://github.com/Icenium/provisioning/tarball/6182eb82dccc073c9be811179c584ff74b5a4587",
     "rimraf": "2.6.2",
     "simple-plist": "0.0.4",
     "temporary": "0.0.8"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "async": "1.2.1",
     "chalk": "1.0.0",
     "cli-table": "0.3.1",
-    "decompress-zip": "0.2.0",
+    "decompress-zip": "0.2.2",
     "entitlements": "1.2.0",
     "glob": "7.1.2",
     "lodash": "4.17.10",


### PR DESCRIPTION
- Fix natives error `ReferenceError: internalBinding is not defined` in decompress-zip
- Update provisioning ref